### PR TITLE
Settings quick-fix

### DIFF
--- a/app/activities/employee/hoursForm/hoursForm.xml
+++ b/app/activities/employee/hoursForm/hoursForm.xml
@@ -5,7 +5,7 @@
         <StackLayout id="actionbar">
             <FlexboxLayout tap="exit" orientation="horizontal" alignItems="center">
                 <Image src="~/icons/arrow-left.png" dock="left"/>
-                <Label text="Powrót" dock="left"/>
+                <Label text="Godziny" dock="left"/>
             </FlexboxLayout>
         </StackLayout>
 

--- a/app/activities/employee/settings/settings.css
+++ b/app/activities/employee/settings/settings.css
@@ -20,7 +20,6 @@
         padding: 0 20;
     }
         #main-defaultRoom > Label {
-            margin-top: 12;
             font-size: 18;
         }
         #main-defaultRoom > TextField {

--- a/app/activities/employee/settings/settings.xml
+++ b/app/activities/employee/settings/settings.xml
@@ -18,13 +18,17 @@
                        flexDirection="column"
                        flexGrow="1"
                        visibility="{{ loading ? 'collapse' : 'visible' }}">
-            <FlexboxLayout id="main-defaultRoom" flexDirection="row">
+            <FlexboxLayout id="main-defaultRoom"
+                           alignItems="center"
+                           flexDirection="row">
                 <Label text="Domyślny Pokój: " />
+                
                 <TextField hint="Pokój"
                            text="{{ room }}"
                            autocorrect="false"
                            isEnabled="{{ roomEditing }}"
                            flexGrow="1"/>
+
                 <StackLayout orientation="horizontal">
                     <Image tap="editRoom" visibility="{{ roomEditing || roomProcessing ? 'collapse' : 'visible' }}" src="~/icons/pencil.png" />
                     <Image tap="acceptEditRoom" visibility="{{ roomEditing ? 'visible' : 'collapse' }}" src="~/icons/check.png" />


### PR DESCRIPTION
# Zmiany
Tekst się teraz wyrównuje dzięki flexboxom a nie marginesem -> bo iphone
Tytuł w hoursForm zmieniony z 'Powrót' na 'Godziny'